### PR TITLE
Fix CI Badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # epiworldpy: Python bindings for epiworld
 
 
-| CI           | status                                                                                                                                                                             |
-|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| conda.recipe | [![Conda Actions Status](https://github.com/UofUEpiBio/epiworldpy/actions/workflows/conda.yml/badge.svg)](https://github.com/UofUEpiBio/epiworldpy/actions?query=workflow%3AConda) |
-| pip builds   | [![Pip Actions Status](https://github.com/UofUEpiBio/epiworldpy/actions/workflows/pip.yml/badge.svg)](https://github.com/UofUEpiBio/epiworldpy/actions?query=workflow%3APip)       |
+[![Pip
+Build](https://github.com/UofUEpiBio/epiworldpy/actions/workflows/pip.yaml/badge.svg)](https://github.com/UofUEpiBio/epiworldpy/actions/workflows/pip.yaml)
 
 This is a python wrapper of the [`epiworld c++`
 library](https://github.com/UofUEpiBio/epiworld), an ABM simulation
@@ -77,7 +75,7 @@ covid19.print(False)
      - Prob. Recovery       : 0.1400
      - Prob. Transmission   : 0.1000
 
-    <epiworldpy._core.ModelSEIRCONN at 0x7fe01a91bcb0>
+    <epiworldpy._core.ModelSEIRCONN at 0x10522f7f0>
 
 And run it and see what we get
 
@@ -100,8 +98,8 @@ covid19.print(False)
     Number of entities  : 0
     Days (duration)     : 100 (of 100)
     Number of viruses   : 1
-    Last run elapsed t  : 105.00ms
-    Last run speed      : 9.47 million agents x day / second
+    Last run elapsed t  : 49.00ms
+    Last run speed      : 20.34 million agents x day / second
     Rewiring            : off
 
     Global actions:
@@ -120,17 +118,17 @@ covid19.print(False)
      - Prob. Transmission   : 0.1000
 
     Distribution of the population at time 100:
-      - (0) Susceptible :  9900 -> 8454
-      - (1) Exposed     :   100 -> 140
-      - (2) Infected    :     0 -> 135
-      - (3) Recovered   :     0 -> 1271
+      - (0) Susceptible :  9900 -> 7500
+      - (1) Exposed     :   100 -> 261
+      - (2) Infected    :     0 -> 238
+      - (3) Recovered   :     0 -> 2001
 
     Transition Probabilities:
      - Susceptible  1.00  0.00  0.00  0.00
      - Exposed      0.00  0.86  0.14  0.00
-     - Infected     0.00  0.00  0.85  0.15
+     - Infected     0.00  0.00  0.86  0.14
      - Recovered    0.00  0.00  0.00  1.00
 
-    <epiworldpy._core.ModelSEIRCONN at 0x7fe01a91bcb0>
+    <epiworldpy._core.ModelSEIRCONN at 0x10522f7f0>
 
 # Acknowledgements

--- a/README.qmd
+++ b/README.qmd
@@ -4,11 +4,7 @@ jupyter: python3
 title: "epiworldpy: Python bindings for epiworld"
 ---
 
-
-|      CI              | status |
-|----------------------|--------|
-| conda.recipe         | [![Conda Actions Status][actions-conda-badge]][actions-conda-link] |
-| pip builds           | [![Pip Actions Status][actions-pip-badge]][actions-pip-link] |
+[![Pip Build](https://github.com/UofUEpiBio/epiworldpy/actions/workflows/pip.yaml/badge.svg)](https://github.com/UofUEpiBio/epiworldpy/actions/workflows/pip.yaml)
 
 This is a python wrapper of the [`epiworld c++` library][epiworld-git], an ABM
 simulation engine. This is possible using the


### PR DESCRIPTION
Previously, the badges reflected the state of the CI system pre-#12; now it just shows `pip` building status.

Fixes #16.