### PR TITLE
Ignore use of `assert`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,3 +90,6 @@ isort.required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.per-file-ignores]
 "tests/**" = ["T20"]
+
+[tool.bandit]
+skips = ["B101"]


### PR DESCRIPTION
This makes Bandit (and by extension Codacy) ignore the use of `assert`. Codacy can't seem to tell test from prod, so whenever `assert` is used in the test cases it will fail CI. This fix is not ideal (we'd still like to be warned about `assert` in real non-test code), but there appears to be no other way to fix it outside of mucking about in the admin portal (which would achieve no better effect).

Reference:
https://github.com/fossasia/query-server/issues/332