### PR TITLE
Stop Checking Headers (Codacy)

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,8 @@
+---
+engines:
+  cppcheck:
+    language: c++
+
+# https://stackoverflow.com/questions/36825903/cppcheck-claims-that-a-field-is-not-used-while-it-is-in-another-file
+exclude_paths:
+  - "src/**.hpp"


### PR DESCRIPTION
For some reason, [Codacy started checking headers with `cppcheck`](https://github.com/UofUEpiBio/epiworldpy/runs/29649099725). which results in a bunch of false-positive warnings about dead code. This, in theory, fixes that. Fixes #40.