### PR TITLE
Add `nbformat` to Optional Dependency Group

### DIFF
--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -1,4 +1,4 @@
-name: shinx
+name: sphinx
 
 on:
   push:

--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -47,8 +47,8 @@ jobs:
       - name: Render Quarto File
         run: quarto render README.qmd --to rst && mv README.rst docs/index.rst
 
-      - name: Build HTML using Poetry
-        run: poetry run -C docs sphinx-build -M html docs/source/ docs/build/
+      - name: Build HTML using Sphinx
+        run: cd docs && sphinx-build -M html docs/source/ docs/build/
 
       # Upload
       - name: Upload artifacts

--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -1,79 +1,79 @@
 name: shinx
 
 on:
-    push:
-        branches: [main]
-    pull_request:
-        branches: [main]
-    release:
-        types: [published]
-    workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-    contents: read
-    pages: write
-    id-token: write
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
-        permissions:
-            contents: write
-        steps:
-            - uses: actions/checkout@v4
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
 
-            # Setting up the environment
-            - name: Setup Pages
-              uses: actions/configure-pages@v5
+      # Setting up the environment
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
 
-            - name: Set up Quarto
-              uses: quarto-dev/quarto-actions/setup@v2
-              with:
-                  version: 1.4.515
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          version: 1.4.515
 
-            - name: Set up Python
-              uses: actions/setup-python@v5
-              with:
-                  python-version: "3.12"
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
 
-            # - name: Install Poetry
-            #   run: pip install poetry
+      # - name: Install Poetry
+      #   run: pip install poetry
 
-            - name: Install the package
-              run: pip install .
+      - name: Install the package
+        run: pip install ".[doc]"
 
-            # Building
-            - name: Render Quarto File
-              run: quarto render README.qmd --to rst && mv README.rst docs/index.rst
+      # Building
+      - name: Render Quarto File
+        run: quarto render README.qmd --to rst && mv README.rst docs/index.rst
 
-            - name: Build HTML using Poetry
-              run: poetry run -C docs sphinx-build -M html docs/source/ docs/build/
+      - name: Build HTML using Poetry
+        run: poetry run -C docs sphinx-build -M html docs/source/ docs/build/
 
-            # Upload
-            - name: Upload artifacts
-              uses: actions/upload-pages-artifact@v3
-              with:
-                  name: github-pages
-                  path: docs/build/html/
+      # Upload
+      - name: Upload artifacts
+        uses: actions/upload-pages-artifact@v3
+        with:
+          name: github-pages
+          path: docs/build/html/
 
-    deploy:
-        # Deploy to the github-pages environment
-        # but not on PRs
-        if: ${{ github.event_name != 'pull_request' }}
-        environment:
-            name: github-pages
-            url: ${{ steps.deployment.outputs.page_url }}
+  deploy:
+    # Deploy to the github-pages environment
+    # but not on PRs
+    if: ${{ github.event_name != 'pull_request' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
-        needs: build
+    needs: build
 
-        # Specify runner + deployment step
-        runs-on: ubuntu-latest
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
 
-        steps:
-            - name: Deploy to GitHub Pages
-              id: deployment
-              uses: actions/deploy-pages@v4
-              with:
-                  artifact_name: github-pages
-                  preview: true # Not yet available to the public.
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          artifact_name: github-pages
+          preview: true # Not yet available to the public.

--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -51,7 +51,7 @@ jobs:
         run: quarto render README.qmd --to rst && mv README.rst docs/index.rst
 
       - name: Build HTML using Sphinx
-        run: cd docs && sphinx-build -M html docs/source/ docs/build/
+        run: sphinx-build -M html docs/source/ docs/build/
 
       # Upload
       - name: Upload artifacts

--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -40,6 +40,9 @@ jobs:
       # - name: Install Poetry
       #   run: pip install poetry
 
+      - name: Install Sphinx
+        run: pip install sphinx
+
       - name: Install the package
         run: pip install ".[doc]"
 

--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -51,7 +51,7 @@ jobs:
         run: quarto render README.qmd --to rst && mv README.rst docs/index.rst
 
       - name: Build HTML using Sphinx
-        run: sphinx-build -M html docs/source/ docs/build/
+        run: sphinx-build -M html docs docs/build/
 
       # Upload
       - name: Upload artifacts

--- a/README.qmd
+++ b/README.qmd
@@ -29,7 +29,7 @@ Here we show how to create a `SEIR` object and add terms to it. We will use the 
 import epiworldpy as epiworld
 
 # Create a SEIR model (susceptible, exposed, infectious, recovered), representing COVID-19.
-covid19 = epiworld.ModelSEIR(
+covid19 = epiworld.ModelSEIRCONN(
   name              = 'covid-19',
   n                 = 10000,
   prevalence        = .01,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 
 [project.optional-dependencies]
 test = ["pytest"]
+doc = ["nbformat"]
 viz = ["ipympl>=0.8", "matplotlib>=3.5.0", "networkx>=3.0", "scipy>=1.0"]
 
 [tool.scikit-build]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 
 [project.optional-dependencies]
 test = ["pytest"]
-doc = ["nbformat"]
+doc = ["nbformat", "nbclient", "jupyter"]
 viz = ["ipympl>=0.8", "matplotlib>=3.5.0", "networkx>=3.0", "scipy>=1.0"]
 
 [tool.scikit-build]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 
 [project.optional-dependencies]
 test = ["pytest"]
-doc = ["nbformat", "nbclient", "jupyter"]
+doc = ["nbformat", "nbclient", "jupyter", "epiworldpy[viz]"]
 viz = ["ipympl>=0.8", "matplotlib>=3.5.0", "networkx>=3.0", "scipy>=1.0"]
 
 [tool.scikit-build]


### PR DESCRIPTION
Should fix #41. We were missing the `nbformat` format, so I added it to an optional dependency group, and `pip` now installs that in the action instead of the default group (à la the `testing` group).